### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WTGlyphFontSet
 
 - Easily use free webfont icons in your iOS projects
 - No setup on the Info.plist
-- drawRect or generate an image in arbitary size
+- drawRect or generate an image in arbitrary size
 - As easy as using [UIImage imageNamed:]
 - Cocoapods support
 - support normal or retina display


### PR DESCRIPTION
@waterlou, I've corrected a typographical error in the documentation of the [WTGlyphFontSet](https://github.com/waterlou/WTGlyphFontSet) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
